### PR TITLE
Update to alluxio to 1.3.0, switch to jdk base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@
 #  https://github.com/int32bit/docker-alluxio
 #
 
-FROM java:8-jre-alpine
+FROM java:openjdk-8-jdk-alpine
 MAINTAINER int32bit krystism@gmail.com
-ENV ALLUXIO_VERSION 1.0.1
+ENV ALLUXIO_VERSION 1.3.0
 
 # Download Alluxio and remove sourcecode
 RUN set -ex \


### PR DESCRIPTION
When running through the [Getting Started](http://www.alluxio.org/docs/master/en/Getting-Started.html) examples using your Dockerfile, I saw the following error when I navigated to either of the UI's

org.apache.jasper.JasperException: PWC6345: There is an error in invoking javac.  A full JDK (not just JRE) is required

Switching from java:8-jre-alpine to java:openjdk-8-jdk-alpine allowed me to move forward.  (there was no 8-jdk-alpine tag)

Also updated to the most current version, 1.3.0
